### PR TITLE
categoryテーブルとexpertテーブルのアソシエーションを1対多へ変更

### DIFF
--- a/app/controllers/experts_controller.rb
+++ b/app/controllers/experts_controller.rb
@@ -6,7 +6,6 @@ class ExpertsController < ApplicationController
 
   def new
     @expert = Expert.new
-    @expert.build_category
   end
 
   def create
@@ -25,6 +24,6 @@ class ExpertsController < ApplicationController
                                    :career,
                                    :contact,
                                    :text,
-                                   category_attributes: [:id, :name]).merge(user_id: current_user.id)
+                                   :category_id).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,7 +1,3 @@
 class Category < ApplicationRecord
-  belongs_to :expert
-
-  # validation
-  # name 空ではないか
-  validates :name, presence: true
+  has_many :expert, dependent: :destroy
 end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -1,12 +1,13 @@
 class Expert < ApplicationRecord
   belongs_to :user, optional: true
-  has_one :category, dependent: :destroy
-  accepts_nested_attributes_for :category
+  belongs_to :category
 
   # validation
   # name 空白ではないか、 最大２０文字
   validates :name, presence: true, length: { maximum: 20}
   # career 空白ではないか
   validates :career, presence: true
+  # category_id 空ではないか
+  validates :category_id, presence: true
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,5 +20,4 @@ class User < ApplicationRecord
   validates :password, confirmation: true, presence: true, length: { in: 7..128 }, format: { with: VALID_PASSWORD_REGEX, message: "半角の英字と数字を両方含むパスワードを設定してください"}, unless: -> { validation_context == :update }
   # password_confirmation 空ではないか、7文字以上128文字以下、半角英数字両方含んでいるか
   validates :password_confirmation, presence: true, unless: -> { validation_context == :update }
-
 end

--- a/app/views/experts/new.html.haml
+++ b/app/views/experts/new.html.haml
@@ -15,16 +15,15 @@
               必須
           = f.text_field :name, class: "expert__input-small", placeholder: "得意分野の名前"
           = render partial: 'modules/expert_error_message', locals: {expert: @expert, column: "name"}
-        = f.fields_for :category, method: :post do |category|
-          .form__container
-            .upper__message
-              = category.label :name, "Category", class: "expert__label"
-              .form__require
-                必須
-            .select__wrapper
-              = fa_icon "chevron-down", class: "select-arrow"
-              = category.select :name, [["カテゴリを選んでください",nil],["ビジネス","ビジネス"],["スポーツ","スポーツ"],["アウトドア趣味(スポーツ以外)","アウトドア趣味(スポーツ以外)"],["ゲーム","ゲーム"],["インドア趣味(ゲーム以外)","インドア趣味(ゲーム以外)"]], {}, {class: "expert__select"}
-              = render partial: 'modules/expert_error_message', locals: {expert: @expert.category, column: "name"}
+        .form__container
+          .upper__message
+            = f.label :category_id, "Category", class: "expert__label"
+            .form__require
+              必須
+          .select__wrapper
+            = fa_icon "chevron-down", class: "select-arrow"
+            = f.select :category_id, [["カテゴリを選んでください",nil],["ビジネス",1],["スポーツ",2],["アウトドア趣味(スポーツ以外)",3],["ゲーム",4],["インドア趣味(ゲーム以外)",5]], {}, {class: "expert__select"}
+            = render partial: 'modules/expert_error_message', locals: {expert: @expert, column: "category_id"}
         .form__container
           .upper__message
             = f.label :career, "Career", class: "expert__label"

--- a/db/migrate/20191201043336_remove_expert_id_from_categories.rb
+++ b/db/migrate/20191201043336_remove_expert_id_from_categories.rb
@@ -1,0 +1,5 @@
+class RemoveExpertIdFromCategories < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :categories, :expert, foreign_key: true
+  end
+end

--- a/db/migrate/20191201043900_add_category_id_to_experts.rb
+++ b/db/migrate/20191201043900_add_category_id_to_experts.rb
@@ -1,0 +1,5 @@
+class AddCategoryIdToExperts < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :experts, :category, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_28_093721) do
+ActiveRecord::Schema.define(version: 2019_12_01_043900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,8 +40,6 @@ ActiveRecord::Schema.define(version: 2019_11_28_093721) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "expert_id"
-    t.index ["expert_id"], name: "index_categories_on_expert_id"
     t.index ["name"], name: "index_categories_on_name"
   end
 
@@ -53,6 +51,8 @@ ActiveRecord::Schema.define(version: 2019_11_28_093721) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_experts_on_category_id"
     t.index ["name"], name: "index_experts_on_name"
     t.index ["user_id"], name: "index_experts_on_user_id"
   end
@@ -72,6 +72,5 @@ ActiveRecord::Schema.define(version: 2019_11_28_093721) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "categories", "experts"
   add_foreign_key "experts", "users"
 end


### PR DESCRIPTION
# What
categoryテーブルとexpertテーブルのアソシエーションを1対多へ変更
# Why
categoryテーブルとexpertテーブルが1対1であると、同じ名前で違うidのカテゴリが大量に作られることになるため、修正の目的で変更