### PR TITLE
タイトルの変更とビュー内の単語の統一

### DIFF
--- a/app/views/experts/_expert.html.haml
+++ b/app/views/experts/_expert.html.haml
@@ -5,11 +5,11 @@
     = image_tag "ques.jpg", class: "member__image"
   .member__info
     .nickname
-      nickname:
+      Nickname:
       = expert.user.nickname
     .expert
-      expert:
+      Expert:
       = expert.name
     .career
-      career:
+      Career:
       = expert.career

--- a/app/views/experts/_expert__form.html.haml
+++ b/app/views/experts/_expert__form.html.haml
@@ -1,6 +1,6 @@
 .form__container
   .upper__message
-    = f.label :name, "Specialty", class: "expert__label"
+    = f.label :name, "Expert", class: "expert__label"
     .form__require
       必須
   = f.text_field :name, class: "expert__input-small", placeholder: "得意分野の名前"

--- a/app/views/experts/show.html.haml
+++ b/app/views/experts/show.html.haml
@@ -21,7 +21,7 @@
         .member-infomation
           .member-infomation__content
             .member__head-title
-              Specialty
+              Expert
             .member__body-message
               = @expert.name
           .member-infomation__content

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,7 +1,7 @@
 .header
   .header__left-box
     = link_to root_path, class: "header__title" do
-      Board
+      ExpBoard
   .header__right-box
     - if user_signed_in?
       =link_to destroy_user_session_path, class: "sign-out__btn", method: :delete do


### PR DESCRIPTION
# What
仮タイトルから本タイトルにヘッダーロゴを変更、ビュー内の単語を統一
# Why
タイトルの更新と単語の統一感がなかったため